### PR TITLE
Updating paths to provide option for private vs production installation

### DIFF
--- a/environments/arc/spack.yaml
+++ b/environments/arc/spack.yaml
@@ -5,17 +5,17 @@
 
 spack:
   # add package specs to the `specs` list
-  specs:
-  - matrix:
-    - [bzip2, blat]
-    - ['%gcc@10.3.0']
-  - gcc@10.3.0
-  view: false
   config:
     install_missing_compilers: true
+  view: false
+  specs:
+  - gcc@10.3.0
+  - matrix:
+    - ['%gcc@10.3.0']
+    - [bzip2, blat]
   compilers:
   - compiler:
-      spec: gcc@8.5.0
+      spec: gcc@8.4.1
       paths:
         cc: /usr/bin/gcc
         cxx: /usr/bin/g++

--- a/spack/etc/spack/config.yaml
+++ b/spack/etc/spack/config.yaml
@@ -1,11 +1,17 @@
 config:
   # This is the path to the root of the Spack install tree.
   install_tree:
-    root: /var/software/$user/bio/pkgs
+    # Use this for private
+    # root: /var/software/$user/bio/pkgs
+    # Use this for production
+    # root: /sw/spack/bio/pkgs
     projections:
       all: "${COMPILERNAME}-${COMPILERVER}/${PACKAGE}/${VERSION}-${HASH:8}"
   module_roots:
-    lmod: /var/software/$user/bio/modules
+    # Use this for private
+    # lmod: /var/software/$user/bio/modules
+    # Use this for production
+    # lmod: /sw/spack/bio/modules
   build_stage:
     - $tempdir/$user/spack-stage
   test_stage: $user_cache_path/test

--- a/spack/etc/spack/modules.yaml
+++ b/spack/etc/spack/modules.yaml
@@ -6,9 +6,11 @@ modules:
       hash_length: 0
       projections:
         all: "{name}/{version}"
+        gcc: "{name}/{version}-spack"
       hierarchy:
         - mpi
       core_compilers:
         - gcc@8.4.1
-#     whitelist: [gcc]
-#     blacklist: ['%gcc@8.4.1']  # prevent generation of module files for any pkg compiled with gcc@8.5.0
+        - gcc@10.3.0
+      whitelist: [gcc]
+      blacklist: ['%gcc@8.4.1']  # prevent generation of module files for any pkg compiled with gcc@8.4.1

--- a/spack/etc/spack/repos.yaml
+++ b/spack/etc/spack/repos.yaml
@@ -1,3 +1,6 @@
 repos:
-- /var/software/$user/bio/local-packages
+# Use this for private
+# - /var/software/$user/bio/local-packages
+# Use this for production
+# - /sw/spack/bio/local-packages
 - $spack/var/spack/repos/builtin


### PR DESCRIPTION
Also, fixed some gcc/8.5.0 references to set to 8.4.1 due to the downgrade and some other minor changes.